### PR TITLE
Fix meson build with newer meson versions

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -3,7 +3,6 @@ desktop_conf.set('app_id', app_id)
 
 
 desktop_file = i18n.merge_file(
-  'desktop',
   input: configure_file(
            input: '@0@.desktop.in'.format(app_id),
            output: '@0@.desktop.in'.format(app_id),


### PR DESCRIPTION
Since meson 0.61.0 `i18n.merge_file` [no longer accepts positional arguments](https://github.com/mesonbuild/meson/pull/9445).

Due to this the build is currently broken with newer Meson versions (e.g. 1.2.3).
